### PR TITLE
Update vulkano-glfw to follow latest rust rules and use latest vulkano, vk-sys, and glfw

### DIFF
--- a/vulkano-glfw/Cargo.toml
+++ b/vulkano-glfw/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "vulkano-glfw"
-version = "0.5.0"
-authors = ["André Twupack <atwupack@mailbox.org>"]
-description = "Utility functions to use GLFW with Vulkano"
+version = "0.6.0"
+authors = ["André Twupack <atwupack@mailbox.org>", "braxtons12 <braxtonsalyer@gmail.com>"]
+description = "Utility functions to use GFLW with Vulkano"
 repository = "https://github.com/atwupack/vulkan4rust"
 license = "MIT"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vulkano = "^0.8"
-vk-sys = "^0.3"
-glfw ={version = "^0.21", features = ["vulkan"]}
+vulkano = "^0.14.0"
+vk-sys = "^0.4.0"
+glfw = { version = "^0.32.0", features = ["vulkan"]}

--- a/vulkano-glfw/src/lib.rs
+++ b/vulkano-glfw/src/lib.rs
@@ -8,42 +8,13 @@ use std::error;
 use std::fmt;
 use std::ffi::CString;
 
-use std::sync::mpsc::Receiver;
 
 use vulkano::VulkanObject;
 use vulkano::instance::{Instance, InstanceExtensions, RawInstanceExtensions, QueueFamily};
 
 use vulkano::swapchain::{Surface};
 
-use glfw::{Window, Context, Glfw, WindowMode, WindowEvent};
-
-pub struct GlfwWindow {
-    window: Window,
-}
-
-impl From<Window> for GlfwWindow {
-    fn from(window: Window) -> Self {
-        GlfwWindow {
-            window: window,
-        }
-    }
-}
-
-pub fn create_glfw_window(glfw: Glfw, width: u32, height: u32, title: &str, mode: WindowMode) -> Option<(GlfwWindow, Receiver<(f64, WindowEvent)>)> {
-    match glfw.create_window(width, height, title, mode) {
-        Some((window, events)) => Some((GlfwWindow::from(window), events)),
-        None => None,
-    }
-}
-
-impl GlfwWindow {
-    pub fn should_close(&self) -> bool {
-        self.window.should_close()
-    }
-}
-
-unsafe impl Send for GlfwWindow {}
-unsafe impl Sync for GlfwWindow {}
+use glfw::{Window, Context, Glfw};
 
 /// error while creating a GLFW-based surface
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -63,7 +34,7 @@ impl error::Error for VulkanoGlfwError {
     }
 
     #[inline]
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             _ => None,
         }
@@ -78,9 +49,9 @@ impl fmt::Display for VulkanoGlfwError {
 }
 
 /// Create a surface from a GLFW window
-pub fn create_window_surface(instance: Arc<Instance>, window: GlfwWindow ) -> Result<Arc<Surface<GlfwWindow>>, VulkanoGlfwError> {
+pub fn create_window_surface(instance: Arc<Instance>, window: Window ) -> Result<Arc<Surface<Window>>, VulkanoGlfwError> {
     let internal_instance = instance.as_ref().internal_object();
-    let internal_window = window.window.window_ptr();
+    let internal_window = window.window_ptr();
     let mut internal_surface: vk_sys::SurfaceKHR = 0;
     let result = unsafe {
         glfw::ffi::glfwCreateWindowSurface(internal_instance, internal_window, ptr::null(), &mut internal_surface as *mut u64 )


### PR DESCRIPTION
Title says it all.
Most changes are just removing things you already had removed in v 0.5.0 (not sure why that's not like that here in the repo?) and then a few version changes in cargo.